### PR TITLE
[#185363325] Add StorageAdmin Policy Binding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,11 +31,16 @@ resource "google_project" "project" {
   skip_delete         = !var.allow_deletion
 }
 
+data "google_client_openid_userinfo" "provider_credentials" {
+
+}
+
+
 resource "google_project_iam_binding" "storage_admin_role" {
   project = google_project.project.project_id
   role    = "roles/storage.admin"
   members = [
-    "user:${var.user_email}"
+  "${can(regex(".+\\.iam\\.gserviceaccount\\.com", )) ? "serviceAccount" : "user" }:${data.google_client_openid_userinfo.provider_credentials.email}"
   ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -28,8 +28,15 @@ resource "google_project" "project" {
   billing_account = var.deployment_project_billing_account
 
   auto_create_network = "false"
+  skip_delete         = !var.allow_deletion
+}
 
-  skip_delete = !var.allow_deletion
+resource "google_project_iam_binding" "storage_admin_role" {
+  project = google_project.project.project_id
+  role    = "roles/storage.admin"
+  members = [
+    "user:${var.user_email}"
+  ]
 }
 
 resource "google_service_account" "generated_service_account" {
@@ -41,9 +48,9 @@ resource "google_service_account" "generated_service_account" {
 
 resource "google_service_account_key" "generated_service_account_key" {
   service_account_id = google_service_account.generated_service_account.email
-  keepers = {
-    project: var.compute_project_id
-    version: var.credential_version
+  keepers            = {
+    project : var.compute_project_id
+    version : var.credential_version
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -93,9 +93,3 @@ variable "cromwell_version" {
 
   description = "Set the version of Cromwell to install"
 }
-
-variable "user_email" {
-  type = string
-  nullable = false
-  description = "Set your email to add to the project IAM policy for accessing specific resources not granted under Project Owner"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,9 @@ variable "cromwell_version" {
 
   description = "Set the version of Cromwell to install"
 }
+
+variable "user_email" {
+  type = string
+  nullable = false
+  description = "Set your email to add to the project IAM policy for accessing specific resources not granted under Project Owner"
+}


### PR DESCRIPTION
So it turns out that `Project Owner` is not a sufficient permission to access buckets or their policies. This change grants the `StorageAdmin` role to the defined user email running the terraform script.