### PR TITLE
Add Logging and Fix Deployment in non default Region 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,32 @@ cromwell_version = "$CROMWELL_VERSION" // defaults to 85
     terraform destroy -var-file=cromwell.tfvars -var=allow_deletion=true
     ```
 
+## Deploying To a different location
+
+The Cloud Life Sciences API supports a number of
+different [locations](https://cloud.google.com/life-sciences/docs/concepts/locations)
+for submitting and jobs to. The location does not correspond to the actual zone used for executing a task
+(that can be controlled via the `zone` attribute in the WDL runtime, or setting the `zone` variable in your `cromwell.tfvars`),
+instead it is where the job metadata is located.
+
+The deployment location is controlled via the `region` variable (default value of `us-central1`). If you would like to
+use one of the alternative regions supported by the Cloud Life Sciences API, simply set the region in your
+`cromwell.tfvars` file to a supported value.
+
+Currently supported values are:
+ - us-central1
+ - us-west2
+ - northamerica-northeast1
+ - europe-west2
+ - europe-west4
+ - asia-southeast1
+ - asia-southeast2
+
+```terraform
+region = northamerica-northeast1
+```
+
+
 ## Importing an existing Project
 
 Applying the default configuration of the engine installer will create a new project to deploy the resources too. This
@@ -141,14 +167,14 @@ this, you can import an existing project and deploy the resources to that.
     terraform import -var-file=cromwell.tfvars google_project.project $PROJECT_ID
     ```
 3. Extract the required variables from the `terraform.tfstate`
-   - `deployment_project_name`
-     1. In the `terraform.tfstate` file, find the resource with: `"type": "google_project"
-     2. In the `instance[0].attributes` find the `name` attribute and copy the value
-     3. Set you `deployment_project_name` to the extracted value in your `cromwell.tfvars`
-   - `deployment_project_billing_account`
-     1. In the `terraform.tfstate` file, find the resource with: `"type": "google_project"
-     2. In the `instance[0].attributes` find the `billing_account` attribute and copy the value
-     3. Set you `deployment_project_billing_account` to the extracted value in your `cromwell.tfvars`
+    - `deployment_project_name`
+        1. In the `terraform.tfstate` file, find the resource with: `"type": "google_project"
+        2. In the `instance[0].attributes` find the `name` attribute and copy the value
+        3. Set you `deployment_project_name` to the extracted value in your `cromwell.tfvars`
+    - `deployment_project_billing_account`
+        1. In the `terraform.tfstate` file, find the resource with: `"type": "google_project"
+        2. In the `instance[0].attributes` find the `billing_account` attribute and copy the value
+        3. Set you `deployment_project_billing_account` to the extracted value in your `cromwell.tfvars`
 4. Once you have updated your `cromwell.tfvars` apply the configuration
    ```bash
     terraform apply -var-file=cromwell.tfvars

--- a/modules/cromwell/cromwell.conf
+++ b/modules/cromwell/cromwell.conf
@@ -71,7 +71,7 @@ backend {
 
         genomics {
           auth = "cromwell-service-account"
-          endpoint-url = "https://lifesciences.googleapis.com/"
+          endpoint-url = "https://${region}-lifesciences.googleapis.com/"
           location: "${region}"
           compute-service-account = "${compute_service_account}"
         }

--- a/modules/cromwell/main.tf
+++ b/modules/cromwell/main.tf
@@ -219,6 +219,7 @@ resource "google_project_iam_member" "deployment_account_deployment_roles" {
   for_each = toset([
     "roles/serviceusage.serviceUsageConsumer",
     "roles/compute.networkUser",
+    "roles/logging.logWriter"
   ])
 
   project = var.deployment_project_id
@@ -242,7 +243,6 @@ resource "google_project_iam_member" "deployment_account_billing_roles" {
   member  = "serviceAccount:${google_service_account.cromwell.email}"
   role    = "roles/serviceusage.serviceUsageConsumer"
 }
-
 
 
 resource "google_service_account_iam_member" "deployment_account_act_as_compute_account" {
@@ -318,8 +318,11 @@ resource "google_compute_instance" "cromwell_vm" {
 
   tags = ["cromwell-server"]
 
+
   metadata = {
-    gce-container-declaration = module.cromwell_container.metadata_value
+    google-logging-enabled       = true
+    google-logging-use-fluentbit = true
+    gce-container-declaration    = module.cromwell_container.metadata_value
   }
 
   labels = {

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "deployment_project_id" {
 variable "deployment_project_name" {
   type     = string
   nullable = true
-  default = null
+  default  = null
 
   description = "The name of a GCP project that will be generated."
 }
@@ -24,7 +24,7 @@ variable "deployment_project_name" {
 variable "deployment_project_folder_id" {
   type     = string
   nullable = true
-  default = null
+  default  = null
 
   description = "The ID of a GCP project folder, in which to create a generated GCP project."
 }
@@ -32,7 +32,7 @@ variable "deployment_project_folder_id" {
 variable "deployment_project_billing_account" {
   type     = string
   nullable = true
-  default = null
+  default  = null
 
   description = "The GCP billing account to use for the generated project."
 }
@@ -56,6 +56,13 @@ variable "billing_project_id" {
 variable "region" {
   type    = string
   default = "us-central1"
+  validation {
+    condition = contains([
+      "us-central1", "us-west2", "northamerica-northeast1", "europe-west2", "europe-west4", "asia-southeast1",
+      "asia-southeast2"
+    ], var.region)
+    error_message = "Region must be one of: us-central1, us-west2, northamerica-northeast1, europe-west2, europe-west4, asia-southeast1, asia-southeast2"
+  }
 
   description = "The GCP region in which to deploy Cromwell and where pipeline jobs are executed."
 }


### PR DESCRIPTION
This PR adds two things

1. Configures logging so the Cromwell VM logs will be shipped to the Gcloud Logging API
1. Configure Permissions for the cromwell SA to publish logs
1. Use Region specific lifesciences API