### PR TITLE
Fix docs for importing an existing project; allow setting project labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,19 @@ this, you can import an existing project and deploy the resources to that.
     - `deployment_project_name`
         1. In the `terraform.tfstate` file, find the resource with: `"type": "google_project"
         2. In the `instance[0].attributes` find the `name` attribute and copy the value
-        3. Set you `deployment_project_name` to the extracted value in your `cromwell.tfvars`
+        3. Set your `deployment_project_name` to the extracted value in your `cromwell.tfvars`
     - `deployment_project_billing_account`
         1. In the `terraform.tfstate` file, find the resource with: `"type": "google_project"
         2. In the `instance[0].attributes` find the `billing_account` attribute and copy the value
-        3. Set you `deployment_project_billing_account` to the extracted value in your `cromwell.tfvars`
+        3. Set your `deployment_project_billing_account` to the extracted value in your `cromwell.tfvars`
+    - `deployment_project_folder_id`
+        1. In the `terraform.tfstate` file, find the resource with: `"type": "google_project"
+        2. In the `instance[0].attributes` find the `folder_id` attribute and copy the value
+        3. Set your `deployment_project_folder_id` to the extracted value in your `cromwell.tfvars`
+    - `deployment_project_labels`
+        1. In the `terraform.tfstate` file, find the resource with: `"type": "google_project"
+        2. In the `instance[0].attributes` find the `labels` attribute and copy the value
+        3. Set your `deployment_project_labels` to the extracted value in your `cromwell.tfvars`
 4. Once you have updated your `cromwell.tfvars` apply the configuration
    ```bash
     terraform apply -var-file=cromwell.tfvars

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,8 @@ resource "google_project" "project" {
 
   auto_create_network = "false"
   skip_delete         = !var.allow_deletion
+
+  labels = var.deployment_project_labels
 }
 
 data "google_client_openid_userinfo" "provider_credentials" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,14 @@ variable "deployment_project_folder_id" {
   description = "The ID of a GCP project folder, in which to create a generated GCP project."
 }
 
+variable "deployment_project_labels" {
+  type     = map(string)
+  nullable = false
+  default  = {}
+
+  description = "Optional labels to apply to the GCP project"
+}
+
 variable "deployment_project_billing_account" {
   type     = string
   nullable = true


### PR DESCRIPTION
- Documents the need to set the folder ID when importing an existing project
- Allows the user to specify project labels as a variable