### PR TITLE
add configurable deletion lifecycle policy

### DIFF
--- a/modules/cromwell/main.tf
+++ b/modules/cromwell/main.tf
@@ -234,6 +234,16 @@ resource "google_storage_bucket" "cromwell_output" {
   location = var.region
   name     = local.cromwell_bucket_name
 
+  lifecycle_rule {
+    condition {
+      age = var.file_age_days
+      matches_suffix = var.file_suffixes_to_delete
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
   force_destroy = var.allow_deletion
 }
 

--- a/modules/cromwell/variables.tf
+++ b/modules/cromwell/variables.tf
@@ -108,3 +108,15 @@ variable "sql_database_version" {
   description = "Database version to use for the Cromwell SQL database"
   type     = string
 }
+
+variable "file_suffixes_to_delete" {
+  description = "List of file suffixes used in the deletion lifecycle policy"
+  type        = list(string)
+  default     = [".gz", ".bam", ".bed", ".bw", ".out", ".tsv", ".bai", ".log"]
+}
+
+variable "file_age_days" {
+  description = "Number of days after which files with the specified suffixes will be deleted"
+  type        = number
+  default     = 14
+}


### PR DESCRIPTION
To help with cost savings default the cromwell output bucket to have a deletion policy where it can remove file types after a specified number of days