### PR TITLE
[CU-86b8gn5xv] Least-privilege for Cromwell runtime + deploy SAs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,14 +16,6 @@ data "google_project" "project" {
   depends_on = [google_project.project[0]]
 }
 
-data "google_client_openid_userinfo" "provider_credentials" {}
-
-resource "google_project_iam_member" "storage_admin_role" {
-  project = data.google_project.project.project_id
-  role    = "roles/storage.admin"
-  member  = "${can(regex(".+\\.iam\\.gserviceaccount\\.com", data.google_client_openid_userinfo.provider_credentials.email)) ? "serviceAccount" : "user" }:${data.google_client_openid_userinfo.provider_credentials.email}"
-}
-
 resource "google_service_account" "generated_service_account" {
   account_id   = "generated-service-account"
   display_name = "Generated Service Account"

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ module "cromwell" {
   allow_deletion                  = var.allow_deletion
   cromwell_version                = var.cromwell_version
   additional_buckets              = var.additional_buckets
+  workflow_outputs_bucket         = var.workflow_outputs_bucket
   sql_maintenance_window_day      = var.cromwell_sql_maintenance_window_day
   sql_maintenance_window_hour     = var.cromwell_sql_maintenance_window_hour
   sql_database_version            = var.cromwell_sql_database_version

--- a/modules/cromwell/main.tf
+++ b/modules/cromwell/main.tf
@@ -204,7 +204,7 @@ resource "google_project_iam_member" "cromwell_additional_buckets_roles" {
 
 resource "google_project_iam_member" "cromwell_batch_admin" {
   project = var.deployment_project_id
-  role    = "roles/batch.admin"
+  role    = "roles/batch.jobsEditor"
   member  = "serviceAccount:${google_service_account.cromwell.email}"
 }
 
@@ -221,10 +221,20 @@ resource "google_project_iam_member" "pipeline_logs_writer" {
   member  = "serviceAccount:${google_service_account.pipeline_compute.email}"
 }
 
-resource "google_project_iam_member" "pipeline_storage_object_admin" {
-  project = var.deployment_project_id
-  role    = "roles/storage.objectAdmin"
-  member  = "serviceAccount:${google_service_account.pipeline_compute.email}"
+# pipeline-sa reads workflow inputs from each additional bucket.
+resource "google_storage_bucket_iam_member" "pipeline_additional_buckets_read" {
+  for_each = { for bucket in var.additional_buckets : bucket.name => bucket }
+
+  bucket = each.value.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.pipeline_compute.email}"
+}
+
+# pipeline-sa writes finalized workflow outputs to the outputs bucket.
+resource "google_storage_bucket_iam_member" "pipeline_workflow_outputs_writer" {
+  bucket = var.workflow_outputs_bucket
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.pipeline_compute.email}"
 }
 
 resource "google_project_iam_member" "pipeline_artifact_registry_reader" {

--- a/modules/cromwell/variables.tf
+++ b/modules/cromwell/variables.tf
@@ -62,6 +62,11 @@ variable "additional_buckets" {
   default = []
 }
 
+variable "workflow_outputs_bucket" {
+  description = "Name of the bucket Cromwell writes finalized workflow file outputs to. Granted object read+write to pipeline-sa."
+  type        = string
+}
+
 variable "google_organization" {
   description = "The name of the organization in the resource hierarchy that the project belongs to"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,11 @@ variable "additional_buckets" {
   nullable = true
 }
 
+variable "workflow_outputs_bucket" {
+  description = "Name of the bucket Cromwell writes finalized workflow file outputs to. Granted object read+write to pipeline-sa."
+  type        = string
+}
+
 variable "cromwell_sql_maintenance_window_day" {
   description = "The day of week (1-7), starting on Monday for the maintenance window"
   type        = number


### PR DESCRIPTION
## What
- **pipeline-sa**: replace project-wide `storage.objectAdmin` with bucket-scoped grants (objectViewer on input buckets, objectUser on the workflow-outputs bucket); keeps the existing bucket-level objectAdmin on the execution bucket. Adds a `workflow_outputs_bucket` variable.
- **cromwell-sa**: `roles/batch.admin` → `roles/batch.jobsEditor`.
- Removes `storage_admin_role`, which granted `roles/storage.admin` to the deploy SA (the applier) — redundant now that the Concourse worker uses the least-privilege ConcourseWorker custom role, and it re-broadened the worker.

## Why
Datadog def-000-l0z least-privilege remediation. Pairs with the deployment-templates PR that wires `workflow_outputs_bucket`.

## Validation
Applied to hfs-pacbio via the canary, running as the reduced deploy SA. pipeline-sa and cromwell-sa now pass def-000-l0z; Cromwell module applied cleanly.

Ticket: https://app.clickup.com/t/86b8gn5xv

🤖 Generated with [Claude Code](https://claude.com/claude-code)