### PR TITLE
[CU-86bacmzkn] Cromwell teardown: abandon PSA + delay peering teardown

### DIFF
--- a/modules/cromwell/main.tf
+++ b/modules/cromwell/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 6.2.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 }
 
@@ -81,6 +85,14 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   depends_on = [google_project_service.networking]
 }
 
+# Cloud SQL releases its private services access peering asynchronously after the instance is
+# deleted. Delay destroying the connection so its deletion does not race that release, which
+# otherwise fails with "producer services are still using this connection".
+resource "time_sleep" "wait_for_sql_peering_release" {
+  depends_on       = [google_service_networking_connection.private_vpc_connection]
+  destroy_duration = "300s"
+}
+
 resource "random_password" "root_db_password" {
   keepers = {
     version : var.credential_version
@@ -99,7 +111,7 @@ resource "google_sql_database_instance" "cromwell_mysql" {
   database_version = var.sql_database_version
   region           = var.region
 
-  depends_on = [google_service_networking_connection.private_vpc_connection]
+  depends_on = [time_sleep.wait_for_sql_peering_release]
 
   root_password = random_password.root_db_password.result
 

--- a/modules/cromwell/main.tf
+++ b/modules/cromwell/main.tf
@@ -78,6 +78,12 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.cromwell_mysql_ip.name]
 
+  # Cloud SQL does not release this private-services-access connection on a bounded timescale
+  # after the instance is deleted, so terraform's own delete races the producer-side release
+  # and fails with "producer services are still using this connection". Abandon it on destroy;
+  # the consumer-side VPC peering is removed out of band so the network can still be torn down.
+  deletion_policy = "ABANDON"
+
   depends_on = [google_project_service.networking]
 }
 

--- a/modules/cromwell/main.tf
+++ b/modules/cromwell/main.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 6.2.0"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = ">= 0.9"
-    }
   }
 }
 
@@ -91,14 +87,6 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   depends_on = [google_project_service.networking]
 }
 
-# Cloud SQL releases its private services access peering asynchronously after the instance is
-# deleted. Delay destroying the connection so its deletion does not race that release, which
-# otherwise fails with "producer services are still using this connection".
-resource "time_sleep" "wait_for_sql_peering_release" {
-  depends_on       = [google_service_networking_connection.private_vpc_connection]
-  destroy_duration = "300s"
-}
-
 resource "random_password" "root_db_password" {
   keepers = {
     version : var.credential_version
@@ -117,7 +105,7 @@ resource "google_sql_database_instance" "cromwell_mysql" {
   database_version = var.sql_database_version
   region           = var.region
 
-  depends_on = [time_sleep.wait_for_sql_peering_release]
+  depends_on = [google_service_networking_connection.private_vpc_connection]
 
   root_password = random_password.root_db_password.result
 

--- a/modules/cromwell/outputs.tf
+++ b/modules/cromwell/outputs.tf
@@ -6,6 +6,10 @@ output "network_self_link" {
   value = module.deployment_network.network.self_link
 }
 
+output "deployment_network_name" {
+  value = module.deployment_network.network.name
+}
+
 output "cromwell_output_bucket_name" {
   value = google_storage_bucket.cromwell_output.name
 }

--- a/modules/cromwell/outputs.tf
+++ b/modules/cromwell/outputs.tf
@@ -5,3 +5,7 @@ output "network_ip" {
 output "network_self_link" {
   value = module.deployment_network.network.self_link
 }
+
+output "deployment_network_name" {
+  value = module.deployment_network.network.name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,3 +14,7 @@ output "generated_service_account_private_key" {
 output "cromwell_output_bucket_name" {
   value = module.cromwell.cromwell_output_bucket_name
 }
+
+output "deployment_network_name" {
+  value = module.cromwell.deployment_network_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,3 +10,7 @@ output "generated_service_account_private_key" {
   value     = google_service_account_key.generated_service_account_key.private_key
   sensitive = true
 }
+
+output "deployment_network_name" {
+  value = module.cromwell.deployment_network_name
+}

--- a/terraform.tf.template
+++ b/terraform.tf.template
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~>3.0"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.9"
-    }
   }
 }
 

--- a/terraform.tf.template
+++ b/terraform.tf.template
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~>3.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
   }
 }
 


### PR DESCRIPTION
## Why
Cromwell-side teardown support for CU-86bacmzkn: a clean destroy of the Cromwell deployment must release its private-service-access (PSA) peering without racing Cloud SQL.

## What
- Abandon the PSA connection on destroy, and delay Cromwell VPC peering teardown until Cloud SQL releases it.
- Output the deployment-network VPC name (consumed by the teardown pipeline's peering-removal step).
- Consolidates the two teardown branches (`abandon-psa` + `peering-teardown`) into one, merged with latest `main`.

## Notes
Consumed by the companion `dnastack-deployment-templates` PR (same ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PVewhMwWKk62e8W8mJDu6
