### PR TITLE
[CU-86bakwwzv] Expose pipeline_sa_email output

### DIFF
--- a/modules/cromwell/outputs.tf
+++ b/modules/cromwell/outputs.tf
@@ -13,3 +13,7 @@ output "deployment_network_name" {
 output "cromwell_output_bucket_name" {
   value = google_storage_bucket.cromwell_output.name
 }
+
+output "pipeline_sa_email" {
+  value = google_service_account.pipeline_compute.email
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,7 @@ output "cromwell_output_bucket_name" {
 output "deployment_network_name" {
   value = module.cromwell.deployment_network_name
 }
+
+output "pipeline_sa_email" {
+  value = module.cromwell.pipeline_sa_email
+}


### PR DESCRIPTION
Surfaces the `pipeline-sa` compute SA email (`google_service_account.pipeline_compute.email`) as a module output (inner `modules/cromwell` + top-level), so consumers can reference it instead of reconstructing `pipeline-sa@<project>.iam.gserviceaccount.com`. Output-only, additive, no resource or behavior changes.

Consumed by dnastack-deployment-templates to populate `pipeline_sa_email` in the GCP env-registry entry (replacing a constructed string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)