### PR TITLE
Pin Cloud NAT tcp_time_wait_timeout_sec to 120s in private_network module [86b95592h]

### DIFF
--- a/modules/private_network/main.tf
+++ b/modules/private_network/main.tf
@@ -52,6 +52,7 @@ resource "google_compute_router_nat" "internet_nat" {
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
   router                             = google_compute_router.internet_router.name
+  tcp_time_wait_timeout_sec          = var.tcp_time_wait_timeout_sec
 
   log_config {
     enable = true

--- a/modules/private_network/variables.tf
+++ b/modules/private_network/variables.tf
@@ -17,3 +17,9 @@ variable "ip_cidr_range" {
   type     = string
   nullable = false
 }
+
+variable "tcp_time_wait_timeout_sec" {
+  description = "TCP TIME_WAIT timeout in seconds for Cloud NAT. Set to 120 to preserve previous default (Google changing new gateways to 30s)."
+  type        = number
+  default     = 120
+}


### PR DESCRIPTION
Pin the TCP TIME_WAIT timeout in the private_network Cloud NAT used by the Cromwell-on-GCP workbench engine installer.

## Motivation
Consistency with the main terraform-gcp and deployment-templates changes for the Google NAT default update.

## Out of scope
- This module is used in specific Cromwell/WES paths; main platform NATs are covered by the other PRs.

Refs: https://app.clickup.com/t/86b95592h